### PR TITLE
docs(aio): move links from nav groups to items

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -87,9 +87,14 @@
 
     {
       "title": "Fundamentals",
-      "url": "guide/fundamentals",
       "tooltip": "The fundamentals of Angular",
       "children": [
+
+        {
+          "url": "guide/fundamentals",
+          "title": "Introduction",
+          "tooltip": "An introduction to the fundamentals of Angular."
+        },
 
         {
           "url": "guide/animations",
@@ -259,9 +264,14 @@
 
     {
       "title": "Techniques",
-      "url": "guide/techniques",
       "tooltip": "Techniques for putting Angular to work in your environment",
       "children": [
+
+        {
+          "url": "guide/techniques",
+          "title": "Introduction",
+          "tooltip": "An introduction to techniques to use when developing with Angular."
+        },
 
         {
           "url": "guide/security",


### PR DESCRIPTION
Fundamentals and Techniques nav groups we also links to pages. This caused
counterintuitive behaviour when clicking on them.

This commit moves each link from the group item to a children item, called
Introduction.

Closes #16604

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

